### PR TITLE
Implement login page

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,5 @@ DB_HOST=localhost
 DB_USER=your_user
 DB_PASS=your_password
 DB_NAME=federacion
+ADMIN_USER=admin
+ADMIN_PASS=secret

--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ Este proyecto es un punto de partida para administrar una federación de patinaj
 
 1. Cree una base de datos MySQL llamada `federacion` y una tabla `disciplinas` con al menos una columna `nombre`.
 2. Copie el archivo `.env.example` a `.env` y ajuste `DB_HOST`, `DB_USER`, `DB_PASS` y `DB_NAME` según su entorno.
+   También puede definir `ADMIN_USER` y `ADMIN_PASS` para el acceso al formulario de login.
 3. Ejecute `composer install` para instalar las dependencias PHP.
 4. Configure Apache para que el directorio `public/` sea el *DocumentRoot* del sitio.
 
 Con esto podrá acceder a `index.php` para listar las disciplinas registradas. Las páginas incluyen las plantillas `templates/header.php` y `templates/footer.php` para reutilizar la misma cabecera y scripts.
+Además se dispone de `/login.php` con un formulario de inicio de sesión básico.

--- a/public/css/login.css
+++ b/public/css/login.css
@@ -1,0 +1,23 @@
+body.login-page {
+    background: linear-gradient(120deg, #f6d365 0%, #fda085 100%);
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.login-container {
+    max-width: 380px;
+    width: 100%;
+    padding: 30px;
+    background: #fff;
+    border-radius: 8px;
+    box-shadow: 0 10px 15px rgba(0,0,0,0.1);
+}
+
+.toggle-password {
+    position: absolute;
+    top: 36px;
+    right: 10px;
+    cursor: pointer;
+}

--- a/public/js/login.js
+++ b/public/js/login.js
@@ -1,0 +1,11 @@
+document.addEventListener('DOMContentLoaded', function () {
+    const toggle = document.getElementById('togglePassword');
+    if (toggle) {
+        toggle.addEventListener('click', function () {
+            const pwd = document.getElementById('password');
+            const type = pwd.getAttribute('type') === 'password' ? 'text' : 'password';
+            pwd.setAttribute('type', type);
+            this.textContent = type === 'password' ? 'Mostrar' : 'Ocultar';
+        });
+    }
+});

--- a/public/login.php
+++ b/public/login.php
@@ -1,0 +1,45 @@
+<?php
+session_start();
+require_once __DIR__ . '/../src/db.php';
+
+$extra_head = '<link rel="stylesheet" href="css/login.css">';
+$extra_footer = '<script src="js/login.js"></script>';
+$body_class = 'login-page';
+$errors = '';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $user = $_POST['username'] ?? '';
+    $pass = $_POST['password'] ?? '';
+
+    if ($user === $_ENV['ADMIN_USER'] && $pass === $_ENV['ADMIN_PASS']) {
+        $_SESSION['user'] = $user;
+        header('Location: index.php');
+        exit;
+    } else {
+        $errors = 'Credenciales incorrectas';
+    }
+}
+
+require_once __DIR__ . '/../templates/header.php';
+?>
+<main class="login-container">
+    <h2 class="text-center mb-4">Iniciar sesión</h2>
+    <?php if ($errors): ?>
+        <div class="alert alert-danger" role="alert">
+            <?php echo htmlspecialchars($errors); ?>
+        </div>
+    <?php endif; ?>
+    <form method="post">
+        <div class="mb-3">
+            <label for="username" class="form-label">Usuario</label>
+            <input type="text" class="form-control" id="username" name="username" required>
+        </div>
+        <div class="mb-3 position-relative">
+            <label for="password" class="form-label">Contraseña</label>
+            <input type="password" class="form-control" id="password" name="password" required>
+            <span id="togglePassword" class="toggle-password text-primary">Mostrar</span>
+        </div>
+        <button type="submit" class="btn btn-primary w-100">Ingresar</button>
+    </form>
+</main>
+<?php require_once __DIR__ . '/../templates/footer.php'; ?>

--- a/templates/footer.php
+++ b/templates/footer.php
@@ -1,3 +1,4 @@
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/js/bootstrap.bundle.min.js"  crossorigin="anonymous"></script>
+<?php if (isset($extra_footer)) echo $extra_footer; ?>
 </body>
 </html>

--- a/templates/header.php
+++ b/templates/header.php
@@ -5,8 +5,9 @@
     <title>Federación de Patinaje</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/css/bootstrap.min.css" rel="stylesheet" crossorigin="anonymous">
     <link rel="stylesheet" href="./../public/css/style.css">
+    <?php if (isset($extra_head)) echo $extra_head; ?>
 </head>
-<body>
+<body<?php if (isset($body_class)) echo ' class="' . $body_class . '"'; ?>>
 <header class="site-header">
   <div class="container d-flex align-items-center justify-content-between py-3">
     <a href="/index.php" class="navbar-brand">
@@ -22,6 +23,7 @@
       <a href="/inscripciones" class="nav-link">Inscripciónes</a>
       <a href="/calendario/index.php" class="nav-link">Calendario 2025</a>
       <a href="/reglamento/index.php" class="nav-link">Reglamento 2025</a>
+      <a href="/login.php" class="nav-link">Login</a>
     </nav>
   </div>
 </header>


### PR DESCRIPTION
## Summary
- add admin credentials placeholders to `.env.example`
- allow extra CSS/JS and body classes in templates
- add login link in header
- create `login.php` with JS and CSS for a modern look
- document login setup in README

## Testing
- `php` and `composer` were unavailable, so no tests were run

------
https://chatgpt.com/codex/tasks/task_b_6847677f29b083259f4bdd0c1c697336